### PR TITLE
Adds charmcraft dependencies

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,3 +16,8 @@ parts:
       - git
       # NOTE(aznashwan): required for installing pyjks:
       - python3-dev
+      # NOTE(claudiub): required for installing cffi:
+      - libffi-dev
+      # NOTE(claudiub): required for installing cryptography (cargo also contains rust):
+      - cargo
+      - libssl-dev


### PR DESCRIPTION
libffi-dev is required by cffi. [1]

cargo, rust, and libssl-dev is required by cryptography. [2]

[1] https://paste.ubuntu.com/p/8Hdtj9wJCx/
[2] https://cryptography.io/en/latest/faq/#installing-cryptography-fails-with-error-can-not-find-rust-compiler
