### PR TITLE
Updates Studio service url to a name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -22,7 +22,7 @@ ENGINE_RELATION_NAME = "legend-engine"
 
 
 APPLICATION_SERVER_UI_PATH = "/studio"
-STUDIO_SERVICE_URL_FORMAT = "%(schema)s://%(host)s:%(port)s%(path)s"
+STUDIO_SERVICE_URL_FORMAT = "%(schema)s://%(host)s%(path)s"
 STUDIO_GITLAB_REDIRECT_URI_FORMAT = "%(base_url)s/log.in/callback"
 STUDIO_UI_CONFIG_FILE_CONTAINER_LOCAL_PATH = "/ui-config.json"
 STUDIO_HTTP_CONFIG_FILE_CONTAINER_LOCAL_PATH = "/http-config.json"
@@ -145,13 +145,12 @@ class LegendStudioCharm(legend_operator_base.BaseFinosLegendCoreServiceCharm):
         return rels
 
     def _get_studio_service_url(self):
-        ip_address = legend_operator_base.get_ip_address()
+        svc_name = self.model.config["external-hostname"] or self.app.name
         return STUDIO_SERVICE_URL_FORMAT % (
             {
                 # NOTE(aznashwan): we always return the plain HTTP endpoint:
                 "schema": legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTP,
-                "host": ip_address,
-                "port": APPLICATION_CONNECTOR_PORT_HTTP,
+                "host": svc_name,
                 "path": APPLICATION_SERVER_UI_PATH,
             }
         )

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -61,3 +61,24 @@ class LegendStudioTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
 
     def test_upgrade_charm(self):
         self._test_upgrade_charm()
+
+    def test_get_studio_service_url(self):
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+        # Test without external-hostname config.
+        actual_url = self.harness.charm._get_studio_service_url()
+
+        expected_url = "http://%s%s" % (
+            self.harness.charm.app.name,
+            charm.APPLICATION_SERVER_UI_PATH,
+        )
+        self.assertEqual(expected_url, actual_url)
+
+        # Test with external-hostname config.
+        hostname = "foo.lish"
+        self.harness.update_config({"external-hostname": hostname})
+        actual_url = self.harness.charm._get_studio_service_url()
+
+        expected_url = "http://%s%s" % (hostname, charm.APPLICATION_SERVER_UI_PATH)
+        self.assertEqual(expected_url, actual_url)


### PR DESCRIPTION
When deploying a Juju Application, a Kubernetes service is spawned bearing the same name as the application. We can use that service name to resolve any addresses between the services. For example, we can use ``http://STUDIO_APP_NAME/studio`` to access STUDIO, instead of ``http://EPHEMERAL_IP:8080/studio``.

This way, even if this charm is upgraded or refreshed, we wouldn't have to update Legend Studio with a new service URL.

Alternatively, we can allow users to bring their own host name by using the ``external-hostname`` config option.