### PR TITLE
Updates the legend-juju-libs library (gitlab relation update)

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -25,7 +25,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -578,7 +578,6 @@ class BaseFinosLegendCharm(charm.CharmBase):
 
     def _on_config_changed(self, event: charm.ConfigChangedEvent):
         """Refreshes the service config."""
-        # TODO(claudiub): Update the SDLC and Engine relations with the new Service URL.
         svc_hostname = self.model.config["external-hostname"] or self.app.name
         self.ingress.update_config({"service-hostname": svc_hostname})
         self._refresh_charm_status()
@@ -754,6 +753,12 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
         redirect_uris = self._get_legend_gitlab_redirect_uris()
         legend_gitlab.set_legend_gitlab_redirect_uris_in_relation_data(
             relation.data[self.app], redirect_uris)
+
+    def _on_config_changed(self, event: charm.ConfigChangedEvent):
+        """Refreshes the service config."""
+        super()._on_config_changed(event)
+        # NOTE(claudiub): We need to update the gitlab integrator with the new URIs as well.
+        self._update_gitlab_relation_callback_uris()
 
     def _on_upgrade_charm(self, _: charm.UpgradeCharmEvent) -> None:
         self._update_gitlab_relation_callback_uris()

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 TEST_CERTIFICATE_BASE64 = """
@@ -339,6 +339,48 @@ class BaseFinosLegendCharmTestCase(unittest.TestCase):
             [mock.call(tuple(self.harness.charm._get_workload_service_names()))])
         self.assertIsInstance(
             self.harness.charm.unit.status, model.ActiveStatus)
+
+    @mock.patch("ops.testing._TestingPebbleClient.restart_services")
+    @mock.patch("ops.testing._TestingPebbleClient.stop_services")
+    def _test_update_config_gitlab_relation(self, _container_stop_mock, _container_restart_mock):
+        self.harness.set_leader()
+        self.harness.begin_with_initial_hooks()
+
+        # Setup the URI getter mock,
+        mock_get_uris = self.patch(self.harness.charm, '_get_legend_gitlab_redirect_uris')
+        fake_callback_uris = ['legendary.callback.url']
+        mock_get_uris.return_value = fake_callback_uris
+
+        # Add the gitlab integrator relation and grab its relation ID.
+        test_data = self.harness.charm._get_relations_test_data()
+        gitlab_rel_name = self.harness.charm._get_legend_gitlab_relation_name()
+        gitlab_rel_data = test_data.pop(gitlab_rel_name)
+        gitlab_rel_id = self._add_relation(gitlab_rel_name, gitlab_rel_data)
+
+        # Add the rest of the necessary relations.
+        for rel_name, rel_data in test_data.items():
+            self._add_relation(rel_name, rel_data)
+            self.harness.update_config()
+
+        # Assert that the unit is currently active.
+        self.assertIsInstance(
+            self.harness.charm.unit.status, model.ActiveStatus)
+
+        # Assert that the initial Callback URIs have been set.
+        relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
+        expected_rel_data = {'legend-gitlab-redirect-uris': json.dumps(fake_callback_uris)}
+        self.assertDictEqual(expected_rel_data, relation_data)
+
+        # Setup for the config update.
+        fake_callback_uris = ['foo.lish']
+        mock_get_uris.return_value = fake_callback_uris
+
+        # Update the external-hostname config option and assert that the relation data changed.
+        self.harness.update_config({"external-hostname": "foo.lish"})
+
+        relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
+        expected_rel_data = {'legend-gitlab-redirect-uris': json.dumps(fake_callback_uris)}
+        self.assertDictEqual(expected_rel_data, relation_data)
 
     @mock.patch("ops.testing._TestingPebbleClient.restart_services")
     @mock.patch("ops.testing._TestingPebbleClient.stop_services")

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -59,6 +59,9 @@ class LegendStudioTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
     def test_relations_waiting(self):
         self._test_relations_waiting()
 
+    def test_config_changed_update_gitlab_relation(self):
+        self._test_update_config_gitlab_relation()
+
     def test_upgrade_charm(self):
         self._test_upgrade_charm()
 


### PR DESCRIPTION
The new updates include the following:

- updates the gitlab integrator relation data with the current Callback URIs on config update (``external-hostname`` changed)

Adds a unit test for config update handle.