### PR TITLE
Adds the enable-tls config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,10 +4,6 @@
 options:
 
   ### Application-related options:
-  #
-  # TODO(aznashwan): add a separate option for https endpoints?
-  # Will need to see what certificates needs installing and where.
-
   server-ui-path:
     type: string
     default: /studio
@@ -30,6 +26,17 @@ options:
       PAC4J actions. Must be one of INFO, WARN, DEBUG, or TRACE, or OFF.
 
   ### Nginx Ingress Integrator-related options:
+  enable-tls:
+    type: boolean
+    default: false
+    description: |
+      Boolean representing whether or not this Legend Application endpoint is
+      accessed through HTTPS. Setting this option will not enable TLS on the
+      service itself, and it is meant to be used in conjunction with the
+      tls-secret-name config option on the Nginx Ingress Integrator Charm.
+      Setting this option will cause the Gitlab Callback URLs to be prefixed
+      by HTTPS instead of HTTP.
+
   external-hostname:
     type: string
     default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -150,10 +150,13 @@ class LegendStudioCharm(legend_operator_base.BaseFinosLegendCoreServiceCharm):
 
     def _get_studio_service_url(self):
         svc_name = self.model.config["external-hostname"] or self.app.name
+        schema = legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTP
+        if self.model.config["enable-tls"]:
+            schema = legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTPS
+
         return STUDIO_SERVICE_URL_FORMAT % (
             {
-                # NOTE(aznashwan): we always return the plain HTTP endpoint:
-                "schema": legend_operator_base.APPLICATION_CONNECTOR_TYPE_HTTP,
+                "schema": schema,
                 "host": svc_name,
                 "path": APPLICATION_SERVER_UI_PATH,
             }

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -85,3 +85,10 @@ class LegendStudioTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
 
         expected_url = "http://%s%s" % (hostname, charm.APPLICATION_SERVER_UI_PATH)
         self.assertEqual(expected_url, actual_url)
+
+        # Test with enable-tls set.
+        self.harness.update_config({"enable-tls": True})
+        actual_url = self.harness.charm._get_studio_service_url()
+
+        expected_url = "https://%s%s" % (hostname, charm.APPLICATION_SERVER_UI_PATH)
+        self.assertEqual(expected_url, actual_url)


### PR DESCRIPTION
When the ``enable-tls`` config option is set, the callback URLs set into the gitlab integrator relation will be HTTPS-prefixed.

This config option will not enable TLS on the Legend Application itself, but it is meant to be used in conjunction with the ``tls-secret-name`` config option on the Nginx Ingress Integrator Charm.