### PR TITLE
Updates the Legend Studio configuration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -207,7 +207,7 @@ class LegendStudioCharm(legend_operator_base.BaseFinosLegendCoreServiceCharm):
             "appName": "studio",
             "env": "test",
             "sdlc": {"url": service_urls["sdlc"]},
-            "metadata": {"url": "__LEGEND_DEPOT_URL__/api"},
+            "depot": {"url": "__LEGEND_DEPOT_URL__/api"},
             "engine": {"url": service_urls["engine"]},
             "documentation": {"url": "https://legend.finos.org"},
             "options": {


### PR DESCRIPTION
Newer versions of Legend Studio require the depot field to be present in its configuration file. Without it, the Studio dashboard
will not function properly.