### PR TITLE
Document credentials expiration error message

### DIFF
--- a/docs/CharmPublishing.md
+++ b/docs/CharmPublishing.md
@@ -8,7 +8,7 @@ charmcraft login --export=secrets-legend.auth --charm=finos-legend-studio-k8s \
       --channel=edge --ttl=15780000
 ```
 
-This token will have to be updated periodically since it has a certain time to live set.
+This token will have to be updated periodically since it has a certain time to live set. If the `charmcraft` process fails with the message "Provided credentials are no longer valid for Charmhub. Regenerate them and try again.", it means you have to export the secrets again by logging in to charmcraft using the instructions written above.
 
 By using the following `gh` command you can skip going through the repository settings to set the secret token:
 


### PR DESCRIPTION
Adds reference to the error message thrown when credentials are expired
for charmcraft.