### PR TITLE
Fix issue when not being leader

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -744,6 +744,9 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
             legend_db_credentials, legend_gitlab_credentials)
 
     def _update_gitlab_relation_callback_uris(self):
+        if not self.unit.is_leader():
+            # We're not the leader, so nothing to do.
+            return
         relation = self._get_relation(self._get_legend_gitlab_relation_name())
         if not relation:
             return
@@ -781,9 +784,7 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
 
     def _on_legend_gitlab_relation_joined(
             self, event: charm.RelationJoinedEvent) -> None:
-        redirect_uris = self._get_legend_gitlab_redirect_uris()
-        legend_gitlab.set_legend_gitlab_redirect_uris_in_relation_data(
-            event.relation.data[self.app], redirect_uris)
+        self._update_gitlab_relation_callback_uris()
 
     def _on_legend_gitlab_relation_changed(
             self, _: charm.RelationChangedEvent) -> None:

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -62,6 +62,9 @@ class LegendStudioTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
     def test_config_changed_update_gitlab_relation(self):
         self._test_update_config_gitlab_relation()
 
+    def test_update_config_gitlab_relation_without_being_leader(self):
+        self._test_update_config_gitlab_relation_without_being_leader()
+
     def test_upgrade_charm(self):
         self._test_upgrade_charm()
 


### PR DESCRIPTION
Fixes an issue when charm units that are not leaders and get hook failed: "config-changed".

Ref: [finos/legend-juju-libs PR#15](https://github.com/finos/legend-juju-libs/pull/15)