### PR TITLE
Adds option for the exposed ingress routes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,3 +43,11 @@ options:
     description: |
       String representing the DNS name this Application should respond to.
       By default, this will be the Application's name.
+
+  use-root-path:
+    type: boolean
+    default: true
+    description: |
+      Boolean representing whether or not this Charm will set up an ingress
+      route for the `/` path. If false, the Charm will set up an ingress route
+      for `/studio` instead.

--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -579,7 +579,10 @@ class BaseFinosLegendCharm(charm.CharmBase):
     def _on_config_changed(self, event: charm.ConfigChangedEvent):
         """Refreshes the service config."""
         svc_hostname = self.model.config["external-hostname"] or self.app.name
-        self.ingress.update_config({"service-hostname": svc_hostname})
+        self.ingress.update_config({
+            "service-hostname": svc_hostname,
+            "path-routes": self._get_ingress_routes(),
+        })
         self._refresh_charm_status()
 
     def _on_workload_container_pebble_ready(

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -357,6 +357,9 @@ class BaseFinosLegendCharmTestCase(unittest.TestCase):
         gitlab_rel_data = test_data.pop(gitlab_rel_name)
         gitlab_rel_id = self._add_relation(gitlab_rel_name, gitlab_rel_data)
 
+        # Add the ingress relation and grab its relation ID.
+        ingress_rel_id = self._add_relation('ingress', {})
+
         # Add the rest of the necessary relations.
         for rel_name, rel_data in test_data.items():
             self._add_relation(rel_name, rel_data)
@@ -380,6 +383,13 @@ class BaseFinosLegendCharmTestCase(unittest.TestCase):
 
         relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
         expected_rel_data = {'legend-gitlab-redirect-uris': json.dumps(fake_callback_uris)}
+        self.assertDictEqual(expected_rel_data, relation_data)
+
+        relation_data = self.harness.get_relation_data(ingress_rel_id, self.harness.charm.app)
+        expected_rel_data = {
+            "service-hostname": "foo.lish",
+            "path-routes": self.harness.charm._get_ingress_routes(),
+        }
         self.assertDictEqual(expected_rel_data, relation_data)
 
     @mock.patch("ops.testing._TestingPebbleClient.restart_services")

--- a/src/charm.py
+++ b/src/charm.py
@@ -68,9 +68,12 @@ class LegendStudioCharm(legend_operator_base.BaseFinosLegendCoreServiceCharm):
     def _get_application_connector_port(cls):
         return APPLICATION_CONNECTOR_PORT_HTTP
 
-    @classmethod
-    def _get_ingress_routes(cls) -> str:
-        return STUDIO_INGRESS_ROUTE
+    def _get_ingress_routes(self) -> str:
+        # If use-root-path is True, we should set up / as the ingress route for
+        # Legend Studio. Otherwise, we should only set up /studio as the ingress route.
+        if self.config["use-root-path"]:
+            return STUDIO_INGRESS_ROUTE
+        return APPLICATION_SERVER_UI_PATH
 
     @classmethod
     def _get_workload_container_name(cls):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -56,6 +56,14 @@ class LegendStudioTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegen
         harness = ops_testing.Harness(LegendStudioTestWrapper)
         return harness
 
+    def test_get_ingress_routes(self):
+        self.harness.begin_with_initial_hooks()
+        # use-root-path is True by default.
+        self.assertEqual("/", self.harness.charm._get_ingress_routes())
+
+        self.harness.update_config({"use-root-path": False})
+        self.assertEqual("/studio", self.harness.charm._get_ingress_routes())
+
     def test_relations_waiting(self):
         self._test_relations_waiting()
 


### PR DESCRIPTION
The Legend Studio application typically serves on `/studio`, however it can serve `/` as well, so a 404 Error is not encountered while accessing the root URI.

However, for the Public instance we would like to route the `/` route to the github pages, which means that we need to be able to tune what the Legend Studio charm exposes as an ingress route.

Adds `use-root-path` config option (True by default). Setting it to False will result in the charm exposing the `/studio` ingress route instead of `/`.